### PR TITLE
Bump sqlmodel and sqlalchemy for Python 3.13 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dotenv==1.0.0
 pydantic==1.10.13
 requests==2.32.2
 requests-oauthlib==1.3.1
-SQLAlchemy==2.0.23
-sqlmodel==0.0.14
+SQLAlchemy==2.0.43
+sqlmodel==0.0.24
 tmdbv3api==1.9.0
 tqdm==4.66.3


### PR DESCRIPTION
This PR updates project dependencies to add support for Python 3.13:

sqlmodel: updated from 0.0.14 → 0.0.24 (adds Python 3.13 support)

sqlalchemy: updated from 2.0.23 → 2.0.43 ("full Python 3.13 support to the extent currently possible" in version 2.0.31 + patches through 2.0.42)

Tested locally:
    python main.py run --save
    python main.py server

These commands ran successfully.

Notes:
    Updates are patch-level; existing functionality is expected to work, though not exhaustively tested.